### PR TITLE
fix responses, documentation has been wrong.

### DIFF
--- a/src/response/media.rs
+++ b/src/response/media.rs
@@ -13,9 +13,9 @@ pub enum Media {
         images: Images,
         cover_image_url: String,
         video_url: Option<String>,
-        duration: i64,
-        hegith: i64,
-        width: i64,
+        duration: Option<i64>,
+        hegith: Option<i64>,
+        width: Option<i64>,
     },
     MultipleImages {
         items: Vec<MixedItem>,


### PR DESCRIPTION
正式なアプリにしても、動画Mediaのこの値はnullである場合があるようです。それゆえ、Optionに変更しました(公式ドキュメントでは、Nullableでは「ない」ことは確認しています)。

![2024-12-03 12 32 24 developers pinterest com f8fd90433f5f](https://github.com/user-attachments/assets/99f6c01d-cf76-463b-9eb9-0ab8b9dffc53)

ドキュメントと挙動の乖離については、このあと公式サポートで質問するつもりです。

よろしくお願いします。